### PR TITLE
update historia usuario HU-008

### DIFF
--- a/src/main/java/projects/bootcamp/adapters/driven/jpa/mysql/adapter/VersionAdapter.java
+++ b/src/main/java/projects/bootcamp/adapters/driven/jpa/mysql/adapter/VersionAdapter.java
@@ -2,6 +2,7 @@ package projects.bootcamp.adapters.driven.jpa.mysql.adapter;
 
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import projects.bootcamp.adapters.driven.jpa.mysql.utils.DataOrdering;
 import projects.bootcamp.adapters.driven.jpa.mysql.entity.VersionEntity;
@@ -30,8 +31,13 @@ public class VersionAdapter implements IVersionPersistencePort {
         }
     }
     @Override
-    public List<Version> getAll(int page, int size, String orderByProperty, boolean direction) {
+    public List<Version> getAllByPagination(int page, int size, String orderByProperty, boolean direction) {
         Pageable pageable = DataOrdering.getOrdering(page, size, direction, orderByProperty);
         return versionEntityMapper.toListVersion(versionRepository.findAll(pageable));
+    }
+    @Override
+    public List<Version> getAll(String orderByProperty, boolean direction) {
+        Sort sort = DataOrdering.getSort(direction, orderByProperty);
+        return versionEntityMapper.toListVersion(versionRepository.findAll(sort));
     }
 }

--- a/src/main/java/projects/bootcamp/adapters/driven/jpa/mysql/mapper/IVersionEntityMapper.java
+++ b/src/main/java/projects/bootcamp/adapters/driven/jpa/mysql/mapper/IVersionEntityMapper.java
@@ -22,7 +22,7 @@ public interface IVersionEntityMapper {
     })
     Version toVersion (VersionEntity versionEntity);
     List<Version> toListVersion (Page<VersionEntity> list);
-
+    List<Version> toListVersion (List<VersionEntity> list);
     @InheritInverseConfiguration
     VersionEntity toVersionEntity (Version version);
 }

--- a/src/main/java/projects/bootcamp/adapters/driven/jpa/mysql/utils/DataOrdering.java
+++ b/src/main/java/projects/bootcamp/adapters/driven/jpa/mysql/utils/DataOrdering.java
@@ -14,4 +14,9 @@ public class DataOrdering {
         return PageRequest.of(page, size, sort);
     }
 
+    public static Sort getSort (boolean direction, String property) {
+        Sort.Order orderPageable = direction ? Sort.Order.desc(property) : Sort.Order.asc(property);
+        return Sort.by(orderPageable);
+    }
+
 }

--- a/src/main/java/projects/bootcamp/domain/api/useCase/VersionCase.java
+++ b/src/main/java/projects/bootcamp/domain/api/useCase/VersionCase.java
@@ -25,12 +25,14 @@ public class VersionCase implements IVersionServicePort {
 
     @Override
     public List<Version> getAll(int page, int size, String orderByProperty, boolean direction, int idBootcamp) {
-        List<Version> versions = versionPersistencePort.getAll(page, size, orderByProperty, direction );
-        return filterByBootcamp(versions, idBootcamp);
+        if (idBootcamp == 0) {
+            return versionPersistencePort.getAllByPagination(page, size, orderByProperty, direction );
+        } else {
+            List<Version> versions = versionPersistencePort.getAll(orderByProperty, direction);
+            return filterByBootcamp(versions, idBootcamp);
+        }
     }
-
     private List<Version> filterByBootcamp (List<Version> versions, int idBootcamp) {
-        if (idBootcamp == 0) return  versions;
         return versions.stream().filter(version -> version.getBootcamp().getIdBootcamp() == idBootcamp).toList();
     }
 }

--- a/src/main/java/projects/bootcamp/domain/spi/IVersionPersistencePort.java
+++ b/src/main/java/projects/bootcamp/domain/spi/IVersionPersistencePort.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 public interface IVersionPersistencePort {
     Version save(Version version);
-    List<Version> getAll(int page, int size, String orderByProperty, boolean direction);
+    List<Version> getAllByPagination(int page, int size, String orderByProperty, boolean direction);
+    List<Version> getAll(String orderByProperty, boolean direction);
 }


### PR DESCRIPTION
### Actualización del requerimiento 

Se actualiza el requerimiento de filtrar las versiones de Bootcamp dependiendo de un Bootcamp en especifico. Debido a que en la versión anterior se obtendrá menos versiones por el tamaño de la pagina. Para arreglar esto, se decide hacer un método aparte que retorne la lista de versiones sin paginar, para posteriormente hacer un paginado. 